### PR TITLE
Use getSelectForFindBy() instead of getSelect()

### DIFF
--- a/HideElementsPlugin.php
+++ b/HideElementsPlugin.php
@@ -70,7 +70,7 @@ class HideElementsPlugin extends Omeka_Plugin_AbstractPlugin
         $settings = $this->_settings;
 
         $table = get_db()->getTable('Element');
-        $select = $table->getSelect()
+        $select = $table->getSelectForFindBy()
             ->order('elements.element_set_id')
             ->order('ISNULL(elements.order)')
             ->order('elements.order');


### PR DESCRIPTION
Possible to accept additional filtering from other plugins (%model%_browse_sql), if some fields/elements should be excluded from HideElements