### PR TITLE
Add an option to check/uncheck all elements of a column

### DIFF
--- a/config-form.php
+++ b/config-form.php
@@ -92,6 +92,31 @@
                 ); ?>
             </td>
         </tr>
-	<?php endforeach; ?>
+    <?php endforeach; ?>
     </tbody>
 </table>
+
+<!-- Add Check/Uncheck All functionality -->
+<script type="text/javascript">
+    function toggleCheckboxesByName(sourceCheckbox, column) {
+        // Get all checkboxes with name attribute starting with columns value
+        const checkboxes = document.querySelectorAll('input[type="checkbox"][name^="'+column+'"]');
+
+        // Loop through and set their checked property
+        for (let i = 0; i < checkboxes.length; i++) {
+            checkboxes[i].checked = sourceCheckbox.checked;
+        }
+    }
+</script>
+
+<div class="field">
+    <div class="two columns omega">
+        <label>Check/Uncheck: </label>
+    </div>
+    <div class="inputs five columns omega">
+        <label><input type="checkbox" onclick="toggleCheckboxesByName(this, 'form')"> form</label>
+        <label><input type="checkbox" onclick="toggleCheckboxesByName(this, 'admin')"> admin</label>
+        <label><input type="checkbox" onclick="toggleCheckboxesByName(this, 'public')"> public</label>
+        <label><input type="checkbox" onclick="toggleCheckboxesByName(this, 'search')"> search</label>
+    </div>
+</div>


### PR DESCRIPTION
We have some instances with ~ 200 metadata entries. So it's a lot of work to go through the list and in the worst case select almost all boxes. 

So I suggest a simple “check all” option to simplify the whole thing. I am open to changes and adjustments.

Here what it looks like:
![image](https://github.com/user-attachments/assets/d41b4d3f-b92a-48de-a826-0de75a859483)
